### PR TITLE
Fix dependency chain between src and examples directories.

### DIFF
--- a/libglacierapp.pro
+++ b/libglacierapp.pro
@@ -1,3 +1,3 @@
 TEMPLATE=subdirs
 SUBDIRS += src examples
-example.depends = src
+examples.depends = src


### PR DESCRIPTION
Simple typo, example sources are in examples sub-directory, not example.
Qmake did not warn about this, but builds would fail randomly.