### PR TITLE
MLITE must be PRIVATE

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,6 +1,8 @@
 set(SRC main.cpp)
 
-find_package(Qt5QuickCompiler)
+if(!USE_QT6)
+    find_package(Qt5QuickCompiler)
+endif()
 qt_add_resources(RESOURCES glacierexample.qrc)
 
 set(PACKAGE glacierexample${LIBGLACIER_PKG_VER})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,7 +12,7 @@ add_qt_library(QT_DEPLIBS "${QT_LIB_LIST}")
 
 if(MLITE_FOUND)
     add_definitions(-DHAS_MLITE5)
-    target_link_libraries(${PACKAGE} PUBLIC PkgConfig::MLITE ${QT_DEPLIBS})
+    target_link_libraries(${PACKAGE} PUBLIC ${QT_DEPLIBS} PRIVATE PkgConfig::MLITE)
 else()
     target_link_libraries(${PACKAGE} ${QT_DEPLIBS})
 endif()


### PR DESCRIPTION
 otherwise it goes into /usr/lib/cmake/glacierapp/GlacierTargets.cmake and breaks build of qtquickcontrols-nemo